### PR TITLE
Detect arch like distros in /etc/os-release check already

### DIFF
--- a/bin/mppinit
+++ b/bin/mppinit
@@ -1132,7 +1132,7 @@ if [ -f /etc/os-release ]
 then
   . /etc/os-release
   [ "${ID}" == "debian" ] || [ "${ID_LIKE}" == "debian" ] && debian=1
-  [ "${ID}" == "arch" ] && arch=1
+  [ "${ID}" == "arch" ] || [ "${ID_LIKE}" == "arch" ] && arch=1
   [ "${ID}" == "centos" ] && centos=1
   [ "${ID}" == "fedora" ] && fedora=1
 else


### PR DESCRIPTION
Even though /etc/arch-release is checked for existence as a fallback and is present on an - up to date as of writing - Manjora system, for some reason the arch variable is not set to 1. This fixes it, since os-release contains ID_LIKE=arch on Manjaro.