### PR TITLE
Improve default mpd.conf

### DIFF
--- a/config/mpd/mpd.conf
+++ b/config/mpd/mpd.conf
@@ -38,7 +38,7 @@ audio_output {
     name            "PulseAudio"
     #type           "pipewire"
     #name           "PipeWire"
-    buffer_time     "50000"   # (50ms); default is 500000 microseconds (0.5s)
+    #buffer_time     "50000"   # (50ms); default is 500000 microseconds (0.5s)
 }
 
 audio_output {


### PR DESCRIPTION
The buffer_time option throws a warning, I'm not sure if it's my mpd version (0.23.5) that doesn't understand it or if it's valid if the pipewire output option is commented out. I suggest commenting it out in the mpd.conf template. If it's not valid at all it could certainly be removed entirely:

```
Jan 22 19:35:02 veery mpd[17417]: config: option 'buffer_time' on line 47 was not recognized
Jan 22 19:35:02 veery systemd[1083]: Started Music Player Daemon.
```

I'd like to include another fix to the mpd.conf, but I'm not sure where in the `mppinit` code is a good place for installing it. To fix this warning, it's sufficient to just install the timidty package - at least on Debian-ish this would work. A clumsy workaround would be to just touch an empty file there but that would lead to an apt-install prompt to the user whether they would like to overwrite the existing conf (the empty file), which is kind of ugly and misleading. So, I'm a little lost in finding out where in `mppinit` the mpd package is actually installed. A quick hint and I'll include it in this PR :-)

```
Jan 22 19:12:38 veery mpd[17020]: decoder: Decoder plugin 'wildmidi' is unavailable: configuration file does not exist: /etc/timidity/timidity.cfg

```