### PR TITLE
Supply --no-confirm when running bandcamp-dl command

### DIFF
--- a/share/calliope/bandcamp-download
+++ b/share/calliope/bandcamp-download
@@ -67,6 +67,7 @@ do
   printf "\nDownloading ${url} ... "
   bandcamp-dl --base-dir="${MUSIC_DIR}" \
               --keep-spaces \
+              --no-confirm \
               --no-slugify ${url} > /dev/null 2>&1
 done
 printf "\n\nBandcamp collections downloads complete\n"


### PR DESCRIPTION
# Description

Fixes issues when releases on Bandcamp are set to private wich sometimes is the case when producers only release parts of albums as previews. In that case bancamp-dl run via MusicPlayerPlus will fail and all subsequent downloads will be skipped.

FIXME I'll open an issue describing the error. Sorry, it's been some  time since the analysis and my fix to upstream...finally find the time to submit this.


# Further notes:

The fix was added to the upstream project in
https://github.com/iheanyi/bandcamp-dl/pull/205.

Release via PyPI is pending, thus I'll set this PR to draft and ask for notification by the upstream project.

Once that is through I'll set this PR to ready to merge. Hope that's fine!